### PR TITLE
Bump generated grunt dependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -3,11 +3,11 @@
   "version": "0.0.0",
   "devDependencies": {
     "grunt": "~0.4.1",
-    "load-grunt-tasks": "~0.1.0",
-    "time-grunt": "~0.1.1",
-    "grunt-newer": "~0.5.4",
+    "load-grunt-tasks": "~0.2.0",
+    "time-grunt": "~0.2.0",
+    "grunt-newer": "~0.6.0",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.6.3",
+    "grunt-contrib-jshint": "~0.8.0",
     "jshint-stylish": "~0.1.3",
     "grunt-reduce": "~0.1.12"
   }


### PR DESCRIPTION
Playing around with the generator at the moment. The grunt build still runs fine after updating these.
